### PR TITLE
Made default quaternion of FMPose (1,0,0,0), Fixes MW-645

### DIFF
--- a/FantasmoSDK/app/src/main/java/com/fantasmo/sdk/models/FMPose.kt
+++ b/FantasmoSDK/app/src/main/java/com/fantasmo/sdk/models/FMPose.kt
@@ -102,7 +102,7 @@ class FMPose {
 
     constructor() {
         this.position = FMPosition(0.0, 0.0, 0.0)
-        this.orientation = FMOrientation(0.0f, 0.0f, 0.0f, 0.0f)
+        this.orientation = FMOrientation(1.0f, 0.0f, 0.0f, 0.0f)
     }
 
     constructor(pose: Pose) {


### PR DESCRIPTION
Squashing instantly, this is a one-character fix